### PR TITLE
compose: map model-runner.docker.internal to host-gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    extra_hosts:
+      - "model-runner.docker.internal:host-gateway"
     environment:
       HOME: /home/node
       TERM: xterm-256color
@@ -23,6 +25,8 @@ services:
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    extra_hosts:
+      - "model-runner.docker.internal:host-gateway"
     environment:
       HOME: /home/node
       TERM: xterm-256color


### PR DESCRIPTION
Adds extra_hosts mapping for model-runner.docker.internal so containers can reach Docker Desktop Model Runner on port 12434 in Compose networks.