### PR TITLE
feat: enforce project namespace integrity for memory writes

### DIFF
--- a/test/scripts/namespace-integrity/fake_pg_memory.py
+++ b/test/scripts/namespace-integrity/fake_pg_memory.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+DB_PATH = Path(os.getenv("STUB_PG_DB", "/tmp/stub_pg_memory_db.json"))
+
+
+def load_db() -> dict:
+    if not DB_PATH.exists():
+        return {"next_id": 1, "records": []}
+    return json.loads(DB_PATH.read_text(encoding="utf-8"))
+
+
+def save_db(db: dict) -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DB_PATH.write_text(json.dumps(db, ensure_ascii=False), encoding="utf-8")
+
+
+def cmd_store(args: list[str]) -> int:
+    if len(args) < 2:
+        print("usage: store <namespace> <content> [tags_json]", file=sys.stderr)
+        return 2
+    namespace, content = args[0], args[1]
+    tags = json.loads(args[2]) if len(args) > 2 else []
+
+    fail_ns = os.getenv("STUB_FAIL_ON_STORE_NAMESPACE", "")
+    if fail_ns and namespace == fail_ns:
+        print(json.dumps({"ok": False, "code": "STUB_STORE_FAIL", "namespace": namespace}), file=sys.stderr)
+        return 9
+
+    db = load_db()
+    rec_id = db["next_id"]
+    db["next_id"] += 1
+    db["records"].append({"id": rec_id, "namespace": namespace, "content": content, "tags": tags})
+    save_db(db)
+    print(json.dumps({"ok": True, "id": rec_id}))
+    return 0
+
+
+def cmd_search(args: list[str]) -> int:
+    if len(args) < 2:
+        print("usage: search <namespace> <query> [limit]", file=sys.stderr)
+        return 2
+    namespace, query = args[0], args[1]
+    limit = int(args[2]) if len(args) > 2 else 5
+
+    db = load_db()
+    candidates = [r for r in db["records"] if r.get("namespace") == namespace]
+
+    q = query.strip('"').lower()
+    if q:
+        candidates = [r for r in candidates if q in str(r.get("content", "")).lower() or any(q in str(t).lower() for t in r.get("tags", []))]
+
+    candidates = list(reversed(candidates))[:limit]
+    print(json.dumps({"ok": True, "results": candidates}))
+    return 0
+
+
+def cmd_get(args: list[str]) -> int:
+    if not args:
+        print("usage: get <id>", file=sys.stderr)
+        return 2
+    target_id = int(args[0])
+    db = load_db()
+    for rec in db["records"]:
+        if int(rec.get("id", -1)) == target_id:
+            print(json.dumps(rec))
+            return 0
+    print(json.dumps({"ok": False, "code": "NOT_FOUND"}), file=sys.stderr)
+    return 4
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: fake_pg_memory.py <search|store|get>", file=sys.stderr)
+        return 2
+    cmd = sys.argv[1]
+    args = sys.argv[2:]
+    if cmd == "store":
+        return cmd_store(args)
+    if cmd == "search":
+        return cmd_search(args)
+    if cmd == "get":
+        return cmd_get(args)
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/namespace-integrity/namespace-integrity.test.ts
+++ b/test/scripts/namespace-integrity/namespace-integrity.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'vitest';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = '/home/node/.openclaw/workspace';
+const TOOLS = join(ROOT, 'tools');
+const TEST_HELPER = join(ROOT, 'test/scripts/namespace-integrity/fake_pg_memory.py');
+
+function runPy(script: string, args: string[], env: Record<string, string> = {}) {
+  const res = spawnSync('python3', [script, ...args], {
+    env: { ...process.env, ...env },
+    encoding: 'utf-8',
+  });
+  return res;
+}
+
+function runSh(script: string, args: string[], env: Record<string, string> = {}) {
+  const res = spawnSync('bash', [script, ...args], {
+    env: { ...process.env, ...env },
+    encoding: 'utf-8',
+  });
+  return res;
+}
+
+function setupEnv() {
+  const dir = mkdtempSync(join(tmpdir(), 'ns-integrity-'));
+  const db = join(dir, 'db.json');
+  const audit = join(dir, 'audit.log');
+  return {
+    dir,
+    db,
+    audit,
+    env: {
+      OPENCLAW_PG_MEMORY_PATH: TEST_HELPER,
+      STUB_PG_DB: db,
+      OPENCLAW_NAMESPACE_AUDIT_LOG: audit,
+      OPENCLAW_ACTOR_ID: 'agent:main:main',
+    },
+  };
+}
+
+describe('namespace integrity tooling', () => {
+  test('correct write resolves active namespace when --namespace is omitted', () => {
+    const t = setupEnv();
+
+    const setActive = runPy(join(TOOLS, 'namespace_integrity.py'), ['set-active', '--namespace', 'project:alpha-lab', '--reason', 'bootstrap'], t.env);
+    expect(setActive.status).toBe(0);
+
+    const checkpoint = runPy(join(TOOLS, 'pg_checkpoint.py'), ['--completed', 'did work'], t.env);
+    expect(checkpoint.status).toBe(0);
+
+    const db = JSON.parse(readFileSync(t.db, 'utf-8'));
+    const writes = db.records.filter((r: any) => r.namespace === 'project:alpha-lab' && String(r.content).includes('checkpoint ts='));
+    expect(writes.length).toBe(1);
+  });
+
+  test('mismatch rejection without force', () => {
+    const t = setupEnv();
+    runPy(join(TOOLS, 'namespace_integrity.py'), ['set-active', '--namespace', 'project:active-a', '--reason', 'bootstrap'], t.env);
+
+    const checkpoint = runPy(
+      join(TOOLS, 'pg_checkpoint.py'),
+      ['--namespace', 'project:other-b', '--completed', 'oops'],
+      t.env,
+    );
+
+    expect(checkpoint.status).not.toBe(0);
+    expect(checkpoint.stderr).toContain('NAMESPACE_MISMATCH');
+  });
+
+  test('forced override works with authorized actor and reason and is audited', () => {
+    const t = setupEnv();
+    runPy(join(TOOLS, 'namespace_integrity.py'), ['set-active', '--namespace', 'project:active-a', '--reason', 'bootstrap'], t.env);
+
+    const checkpoint = runPy(
+      join(TOOLS, 'pg_checkpoint.py'),
+      [
+        '--namespace',
+        'project:other-b',
+        '--force-cross-project',
+        '--reason',
+        'intentional migration checkpoint',
+        '--completed',
+        'forced write',
+      ],
+      t.env,
+    );
+
+    expect(checkpoint.status).toBe(0);
+    expect(existsSync(t.audit)).toBe(true);
+    const audit = readFileSync(t.audit, 'utf-8');
+    expect(audit).toContain('cross_project_force_override');
+  });
+
+  test('scope switch semantics: enforce active match and do not change active on checkpoint failure', () => {
+    const t = setupEnv();
+    runPy(join(TOOLS, 'namespace_integrity.py'), ['set-active', '--namespace', 'project:alpha', '--reason', 'bootstrap'], t.env);
+
+    const mismatch = runSh(join(TOOLS, 'pg_scope_switch.sh'), ['project:not-active', 'project:beta', 'handoff'], t.env);
+    expect(mismatch.status).not.toBe(0);
+    expect(mismatch.stderr).toContain('SCOPE_SWITCH_FROM_MISMATCH');
+
+    const failedSwitch = runSh(
+      join(TOOLS, 'pg_scope_switch.sh'),
+      ['project:alpha', 'project:beta', 'handoff'],
+      { ...t.env, STUB_FAIL_ON_STORE_NAMESPACE: 'project:alpha' },
+    );
+    expect(failedSwitch.status).not.toBe(0);
+
+    const active = runPy(join(TOOLS, 'namespace_integrity.py'), ['get-active'], t.env);
+    expect(active.status).toBe(0);
+    const activePayload = JSON.parse(active.stdout);
+    expect(activePayload.namespace).toBe('project:alpha');
+  });
+
+  test('sanitize utility runs dry-run by default and does not move records', () => {
+    const t = setupEnv();
+
+    runPy(TEST_HELPER, ['store', 'project:source', 'namespace=project:target project:target marker', '[]'], t.env);
+    runPy(TEST_HELPER, ['store', 'project:source', 'mentions project:target once', '[]'], t.env);
+    runPy(TEST_HELPER, ['store', 'project:source', 'unrelated content', '[]'], t.env);
+
+    const sanitize = runPy(
+      join(TOOLS, 'namespace_sanitize.py'),
+      ['--source-namespace', 'project:source', '--target-namespace', 'project:target', '--query', 'project:'],
+      t.env,
+    );
+
+    expect(sanitize.status).toBe(0);
+    const payload = JSON.parse(sanitize.stdout);
+    expect(payload.dryRun).toBe(true);
+    expect(payload.counts.moved).toBe(0);
+    expect(payload.counts.autoMove).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tools/dev_execution_rails.sh
+++ b/tools/dev_execution_rails.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE_POLICY="${SCRIPT_DIR}/namespace_integrity.py"
+PG_MEMORY_SCRIPT="${OPENCLAW_PG_MEMORY_PATH:-${SCRIPT_DIR}/pg_memory.py}"
+
+# Run software-dev quality gates and store structured result in Postgres.
+
+TASK_ID=""
+NAMESPACE=""
+FORCE_CROSS_PROJECT=0
+FORCE_REASON=""
+LINT_CMD="${DEV_LINT_CMD:-}"
+TYPE_CMD="${DEV_TYPECHECK_CMD:-}"
+TEST_CMD="${DEV_TEST_CMD:-}"
+SMOKE_CMD="${DEV_SMOKE_CMD:-}"
+WORKDIR="${DEV_WORKDIR:-$(pwd)}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --task-id)
+      TASK_ID="$2"; shift 2 ;;
+    --namespace)
+      NAMESPACE="$2"; shift 2 ;;
+    --force-cross-project)
+      FORCE_CROSS_PROJECT=1; shift ;;
+    --reason)
+      FORCE_REASON="$2"; shift 2 ;;
+    --workdir)
+      WORKDIR="$2"; shift 2 ;;
+    --lint)
+      LINT_CMD="$2"; shift 2 ;;
+    --typecheck)
+      TYPE_CMD="$2"; shift 2 ;;
+    --test)
+      TEST_CMD="$2"; shift 2 ;;
+    --smoke)
+      SMOKE_CMD="$2"; shift 2 ;;
+    *)
+      echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TASK_ID" ]]; then
+  echo "Missing --task-id" >&2
+  exit 2
+fi
+
+RESOLVE_CMD=(python3 "$NAMESPACE_POLICY" resolve-write --operation "dev_execution_rails")
+if [[ -n "$NAMESPACE" ]]; then
+  RESOLVE_CMD+=(--namespace "$NAMESPACE")
+fi
+if [[ "$FORCE_CROSS_PROJECT" -eq 1 ]]; then
+  RESOLVE_CMD+=(--force-cross-project)
+fi
+if [[ -n "$FORCE_REASON" ]]; then
+  RESOLVE_CMD+=(--reason "$FORCE_REASON")
+fi
+
+set +e
+RESOLUTION_JSON="$(${RESOLVE_CMD[@]} 2>&1)"
+RESOLVE_RC=$?
+set -e
+if [[ $RESOLVE_RC -ne 0 ]]; then
+  echo "$RESOLUTION_JSON" >&2
+  exit $RESOLVE_RC
+fi
+
+NAMESPACE="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["namespace"])' <<<"$RESOLUTION_JSON")"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="/home/node/.openclaw/workspace/.runtime/dev-rails/${TASK_ID}/${TS}"
+mkdir -p "$RUN_DIR"
+
+run_gate() {
+  local name="$1"
+  local cmd="$2"
+  local log="$RUN_DIR/${name}.log"
+
+  if [[ -z "$cmd" ]]; then
+    echo "SKIP: no command configured" > "$log"
+    echo "skip"
+    return 0
+  fi
+
+  set +e
+  (cd "$WORKDIR" && bash -lc "$cmd") >"$log" 2>&1
+  local rc=$?
+  set -e
+
+  if [[ $rc -eq 0 ]]; then
+    echo "pass"
+  else
+    echo "fail"
+  fi
+}
+
+LINT_STATUS="$(run_gate lint "$LINT_CMD")"
+TYPE_STATUS="$(run_gate typecheck "$TYPE_CMD")"
+TEST_STATUS="$(run_gate test "$TEST_CMD")"
+SMOKE_STATUS="$(run_gate smoke "$SMOKE_CMD")"
+
+OVERALL="pass"
+for s in "$LINT_STATUS" "$TYPE_STATUS" "$TEST_STATUS" "$SMOKE_STATUS"; do
+  if [[ "$s" == "fail" ]]; then
+    OVERALL="fail"
+    break
+  fi
+done
+
+FAIL_SNIPPETS=""
+for gate in lint typecheck test smoke; do
+  case "$gate" in
+    lint) status="$LINT_STATUS" ;;
+    typecheck) status="$TYPE_STATUS" ;;
+    test) status="$TEST_STATUS" ;;
+    smoke) status="$SMOKE_STATUS" ;;
+  esac
+  if [[ "$status" == "fail" ]]; then
+    snippet="$(tail -n 25 "$RUN_DIR/${gate}.log" | tr '\n' ' ' | tr '\r' ' ' | sed 's/\s\+/ /g' | cut -c1-450)"
+    FAIL_SNIPPETS+="${gate}:${snippet}; "
+  fi
+done
+
+CONTENT=$(cat <<EOF
+
+dev_execution_rails_result v=1
+task_id=${TASK_ID}
+timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+workdir=${WORKDIR}
+overall=${OVERALL}
+lint=${LINT_STATUS}
+typecheck=${TYPE_STATUS}
+test=${TEST_STATUS}
+smoke=${SMOKE_STATUS}
+run_dir=${RUN_DIR}
+failure_snippets=${FAIL_SNIPPETS}
+EOF
+)
+
+STORE_OUT="$(python3 "$PG_MEMORY_SCRIPT" store "$NAMESPACE" "$CONTENT" '["dev-execution-rails", "task:'"$TASK_ID"'"]')"
+
+if [[ "$OVERALL" == "fail" ]]; then
+  SUMMARY="Execution rails failed for ${TASK_ID}"
+  ROOT_CAUSE="One or more quality gates failed (see stored rail result and logs)."
+  PREVENTION="Address failing gates before merge; enforce same rails in CI."
+  python3 "${SCRIPT_DIR}/dev_postmortem.py" \
+    --task-id "$TASK_ID" \
+    --phase "verification" \
+    --summary "$SUMMARY" \
+    --root-cause "$ROOT_CAUSE" \
+    --prevention "$PREVENTION" \
+    --artifacts "$RUN_DIR/lint.log,$RUN_DIR/typecheck.log,$RUN_DIR/test.log,$RUN_DIR/smoke.log" \
+    --namespace "$NAMESPACE" >/dev/null
+fi
+
+echo "DEV_EXECUTION_RAILS_RESULT overall=${OVERALL} namespace=${NAMESPACE} run_dir=${RUN_DIR} store=${STORE_OUT}"
+
+if [[ "$OVERALL" == "fail" ]]; then
+  exit 1
+fi

--- a/tools/dev_lessons.py
+++ b/tools/dev_lessons.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Retrieve concise failure lessons from Postgres before implementation work."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent
+PG_MEMORY = Path(os.getenv("OPENCLAW_PG_MEMORY_PATH", str(TOOLS_DIR / "pg_memory.py")))
+NAMESPACE_POLICY = TOOLS_DIR / "namespace_integrity.py"
+
+
+def parse_kv(content: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def run_search(namespace: str, query: str, limit: int) -> list[dict]:
+    cmd = ["python3", str(PG_MEMORY), "search", namespace, query, str(limit)]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    payload = json.loads(out.stdout)
+    return payload.get("results", []) if isinstance(payload, dict) else []
+
+
+def resolve_read_namespace(explicit_namespace: str | None) -> str:
+    if explicit_namespace:
+        return explicit_namespace
+
+    cmd = ["python3", str(NAMESPACE_POLICY), "get-active"]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr or proc.stdout)
+        raise SystemExit(proc.returncode)
+    payload = json.loads(proc.stdout)
+    return str(payload["namespace"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Load relevant dev failure lessons from Postgres")
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--task-id")
+    parser.add_argument("--namespace")
+    parser.add_argument("--limit", type=int, default=5)
+    args = parser.parse_args()
+
+    namespace = resolve_read_namespace(args.namespace)
+
+    search_query = f"dev_failure_postmortem {args.query}".strip()
+    results = run_search(namespace, search_query, args.limit)
+    if not results:
+        # Fallback: retrieve recent postmortems if semantic query is sparse.
+        results = run_search(namespace, "dev_failure_postmortem", args.limit)
+
+    if args.task_id:
+        task_hits = run_search(namespace, f"dev_failure_postmortem task_id={args.task_id}", args.limit)
+        by_id = {str(item.get("id")): item for item in results}
+        for item in task_hits:
+            by_id[str(item.get("id"))] = item
+        results = list(by_id.values())
+
+    lessons: list[dict[str, str]] = []
+    for item in results:
+        content = str(item.get("content") or "")
+        parsed = parse_kv(content)
+        if parsed.get("dev_failure_postmortem v") != "1":
+            continue
+        lessons.append(
+            {
+                "id": str(item.get("id")),
+                "task": parsed.get("task_id", "unknown"),
+                "phase": parsed.get("phase", "unknown"),
+                "summary": parsed.get("failure_summary", ""),
+                "rootCause": parsed.get("root_cause", ""),
+                "prevention": parsed.get("prevention_actions", ""),
+            }
+        )
+
+    print(json.dumps({"count": len(lessons), "namespace": namespace, "lessons": lessons}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dev_postmortem.py
+++ b/tools/dev_postmortem.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Store a structured software-dev failure postmortem in Postgres memory."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent
+PG_MEMORY = Path(os.getenv("OPENCLAW_PG_MEMORY_PATH", str(TOOLS_DIR / "pg_memory.py")))
+NAMESPACE_POLICY = TOOLS_DIR / "namespace_integrity.py"
+
+
+def run_pg_store(namespace: str, content: str, tags: list[str]) -> dict:
+    cmd = [
+        "python3",
+        str(PG_MEMORY),
+        "store",
+        namespace,
+        content,
+        json.dumps(tags, ensure_ascii=False),
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(out.stdout)
+
+
+def resolve_namespace(explicit_namespace: str | None, force: bool, reason: str, operation: str) -> dict:
+    cmd = ["python3", str(NAMESPACE_POLICY), "resolve-write", "--operation", operation]
+    if explicit_namespace:
+        cmd.extend(["--namespace", explicit_namespace])
+    if force:
+        cmd.append("--force-cross-project")
+    if reason:
+        cmd.extend(["--reason", reason])
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr or proc.stdout)
+        raise SystemExit(proc.returncode)
+    return json.loads(proc.stdout)
+
+
+def csv_to_list(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def build_content(args: argparse.Namespace) -> str:
+    now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    lines: list[str] = [
+        "dev_failure_postmortem v=1",
+        f"task_id={args.task_id}",
+        f"phase={args.phase}",
+        f"timestamp_utc={now}",
+        f"failure_summary={args.summary.strip()}",
+        f"root_cause={args.root_cause.strip() if args.root_cause else 'unspecified'}",
+    ]
+
+    if args.impact:
+        lines.append(f"impact={args.impact.strip()}")
+    if args.detection:
+        lines.append(f"detection={args.detection.strip()}")
+    if args.fix:
+        lines.append(f"fix={args.fix.strip()}")
+    if args.prevention:
+        lines.append(f"prevention_actions={args.prevention.strip()}")
+
+    artifacts = csv_to_list(args.artifacts)
+    if artifacts:
+        lines.append(f"artifacts={'; '.join(artifacts)}")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Store structured dev postmortem in Postgres")
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--phase", default="implementation")
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--root-cause")
+    parser.add_argument("--impact")
+    parser.add_argument("--detection")
+    parser.add_argument("--fix")
+    parser.add_argument("--prevention")
+    parser.add_argument("--artifacts", help="comma-separated file/artifact paths")
+    parser.add_argument("--namespace")
+    parser.add_argument("--force-cross-project", action="store_true")
+    parser.add_argument("--reason", default="")
+    parser.add_argument("--mirror-namespace", default="capability:dev-failure-lessons")
+    parser.add_argument("--no-mirror", action="store_true")
+    args = parser.parse_args()
+
+    resolution = resolve_namespace(
+        args.namespace,
+        force=args.force_cross_project,
+        reason=args.reason,
+        operation="dev_postmortem",
+    )
+    namespace = resolution["namespace"]
+
+    content = build_content(args)
+    tags = [
+        "dev-failure-postmortem",
+        f"task:{args.task_id}",
+        f"phase:{args.phase}",
+    ]
+
+    primary = run_pg_store(namespace, content, tags)
+    result: dict[str, object] = {
+        "ok": True,
+        "namespace": namespace,
+        "activeNamespace": resolution.get("activeNamespace"),
+        "forced": bool(resolution.get("forced")),
+        "id": primary.get("id"),
+    }
+
+    if not args.no_mirror:
+        mirror = run_pg_store(args.mirror_namespace, content, tags)
+        result["mirrorNamespace"] = args.mirror_namespace
+        result["mirrorId"] = mirror.get("id")
+
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dev_web_external_qa.sh
+++ b/tools/dev_web_external_qa.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE_POLICY="${SCRIPT_DIR}/namespace_integrity.py"
+PG_MEMORY_SCRIPT="${OPENCLAW_PG_MEMORY_PATH:-${SCRIPT_DIR}/pg_memory.py}"
+
+# External web-delivery QA gate.
+
+TASK_ID=""
+BASE_URL=""
+AUTH_PATH="/auth/start"
+DASHBOARD_PATH="/dashboard"
+MOBILE_PATH="/m"
+NAMESPACE=""
+FORCE_CROSS_PROJECT=0
+FORCE_REASON=""
+WORKDIR="${DEV_WORKDIR:-$(pwd)}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --task-id) TASK_ID="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --auth-path) AUTH_PATH="$2"; shift 2 ;;
+    --dashboard-path) DASHBOARD_PATH="$2"; shift 2 ;;
+    --mobile-path) MOBILE_PATH="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --force-cross-project) FORCE_CROSS_PROJECT=1; shift ;;
+    --reason) FORCE_REASON="$2"; shift 2 ;;
+    --workdir) WORKDIR="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TASK_ID" || -z "$BASE_URL" ]]; then
+  echo "Missing required args: --task-id and --base-url" >&2
+  exit 2
+fi
+
+RESOLVE_CMD=(python3 "$NAMESPACE_POLICY" resolve-write --operation "dev_web_external_qa")
+if [[ -n "$NAMESPACE" ]]; then
+  RESOLVE_CMD+=(--namespace "$NAMESPACE")
+fi
+if [[ "$FORCE_CROSS_PROJECT" -eq 1 ]]; then
+  RESOLVE_CMD+=(--force-cross-project)
+fi
+if [[ -n "$FORCE_REASON" ]]; then
+  RESOLVE_CMD+=(--reason "$FORCE_REASON")
+fi
+
+set +e
+RESOLUTION_JSON="$(${RESOLVE_CMD[@]} 2>&1)"
+RESOLVE_RC=$?
+set -e
+if [[ $RESOLVE_RC -ne 0 ]]; then
+  echo "$RESOLUTION_JSON" >&2
+  exit $RESOLVE_RC
+fi
+
+NAMESPACE="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["namespace"])' <<<"$RESOLUTION_JSON")"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="/home/node/.openclaw/workspace/.runtime/dev-web-qa/${TASK_ID}/${TS}"
+mkdir -p "$RUN_DIR"
+
+normalize_url() {
+  local base="$1"
+  local path="$2"
+  if [[ -z "$path" ]]; then
+    echo "$base"
+    return 0
+  fi
+  if [[ "$path" =~ ^https?:// ]]; then
+    echo "$path"
+    return 0
+  fi
+  if [[ "$path" == /* ]]; then
+    echo "${base%/}${path}"
+  else
+    echo "${base%/}/$path"
+  fi
+}
+
+check_url() {
+  local label="$1"
+  local url="$2"
+  local ua="${3:-}"
+  local code=""
+  local log="$RUN_DIR/${label}.log"
+
+  local curl_cmd=(curl -sS -o /dev/null -w "%{http_code}" -L --max-time 25)
+  if [[ -n "$ua" ]]; then
+    curl_cmd+=( -A "$ua" )
+  fi
+  set +e
+  code="$("${curl_cmd[@]}" "$url" 2>"$log")"
+  rc=$?
+  set -e
+
+  if [[ $rc -ne 0 ]]; then
+    echo "fail|curl_error|$url"
+    return 0
+  fi
+
+  if [[ "$code" =~ ^2[0-9][0-9]$ || "$code" =~ ^3[0-9][0-9]$ || "$code" == "401" || "$code" == "403" ]]; then
+    echo "pass|$code|$url"
+  else
+    echo "fail|$code|$url"
+  fi
+}
+
+HOME_URL="$(normalize_url "$BASE_URL" "/")"
+AUTH_URL="$(normalize_url "$BASE_URL" "$AUTH_PATH")"
+DASHBOARD_URL="$(normalize_url "$BASE_URL" "$DASHBOARD_PATH")"
+MOBILE_URL="$(normalize_url "$BASE_URL" "$MOBILE_PATH")"
+
+HOME_RES="$(check_url home "$HOME_URL")"
+AUTH_RES="$(check_url auth_start "$AUTH_URL")"
+DASH_RES="$(check_url dashboard "$DASHBOARD_URL")"
+MOBILE_RES="$(check_url mobile "$MOBILE_URL" "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1")"
+
+overall="pass"
+for res in "$HOME_RES" "$AUTH_RES" "$DASH_RES" "$MOBILE_RES"; do
+  status="${res%%|*}"
+  if [[ "$status" != "pass" ]]; then
+    overall="fail"
+    break
+  fi
+done
+
+CONTENT=$(cat <<EOF
+
+dev_web_external_qa_result v=1
+task_id=${TASK_ID}
+timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+workdir=${WORKDIR}
+base_url=${BASE_URL}
+overall=${overall}
+home=${HOME_RES}
+auth_start=${AUTH_RES}
+dashboard=${DASH_RES}
+mobile=${MOBILE_RES}
+run_dir=${RUN_DIR}
+rule=works_locally_but_broken_externally_is_failed_delivery
+EOF
+)
+
+STORE_OUT="$(python3 "$PG_MEMORY_SCRIPT" store "$NAMESPACE" "$CONTENT" '["dev-web-external-qa", "task:'"$TASK_ID"'"]')"
+
+if [[ "$overall" == "fail" ]]; then
+  python3 "${SCRIPT_DIR}/dev_postmortem.py" \
+    --task-id "$TASK_ID" \
+    --phase "verification" \
+    --summary "External web QA failed for real delivery URL path" \
+    --root-cause "One or more external URL checks failed (home/auth/dashboard/mobile)" \
+    --prevention "Run dev_web_external_qa gate before handoff; do not mark done until all external routes pass" \
+    --artifacts "$RUN_DIR/home.log,$RUN_DIR/auth_start.log,$RUN_DIR/dashboard.log,$RUN_DIR/mobile.log" \
+    --namespace "$NAMESPACE" >/dev/null
+fi
+
+echo "DEV_WEB_EXTERNAL_QA_RESULT overall=${overall} namespace=${NAMESPACE} run_dir=${RUN_DIR} store=${STORE_OUT}"
+
+if [[ "$overall" == "fail" ]]; then
+  exit 1
+fi

--- a/tools/namespace_integrity.py
+++ b/tools/namespace_integrity.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Namespace integrity guardrails for Postgres memory tooling.
+
+Provides a shared policy resolver used by local scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import getpass
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_NAMESPACE_RE = re.compile(r"^project:[a-z0-9][a-z0-9-]{1,63}$")
+ACTIVE_NAMESPACE_KEY = "system:config.active_project_namespace"
+ACTIVE_NAMESPACE_STORE = ACTIVE_NAMESPACE_KEY
+FORCE_ALLOWLIST_DEFAULT = {"agent:main:main", "owner:+13479278207"}
+VALID_REASONS = {"scope-switch", "bootstrap", "manual"}
+
+TOOLS_DIR = Path(__file__).resolve().parent
+PG_MEMORY_PATH = Path(os.getenv("OPENCLAW_PG_MEMORY_PATH", str(TOOLS_DIR / "pg_memory.py")))
+AUDIT_LOG_PATH = Path(
+    os.getenv(
+        "OPENCLAW_NAMESPACE_AUDIT_LOG",
+        "/home/node/.openclaw/workspace/.runtime/namespace-integrity/audit.log",
+    )
+)
+
+
+class NamespacePolicyError(RuntimeError):
+    def __init__(self, code: str, message: str, *, details: dict[str, Any] | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "error": {
+                "code": self.code,
+                "message": self.message,
+                "details": self.details,
+            },
+        }
+
+
+@dataclass
+class ActiveNamespaceRecord:
+    namespace: str
+    updated_at: str
+    updated_by: str
+    reason: str
+    v: int = 1
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "v": self.v,
+            "namespace": self.namespace,
+            "updatedAt": self.updated_at,
+            "updatedBy": self.updated_by,
+            "reason": self.reason,
+        }
+
+
+def _run_pg_memory(args: list[str]) -> dict[str, Any]:
+    cmd = ["python3", str(PG_MEMORY_PATH), *args]
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    if out.returncode != 0:
+        raise NamespacePolicyError(
+            "PG_MEMORY_ERROR",
+            "pg_memory command failed",
+            details={"command": " ".join(cmd), "stderr": out.stderr.strip(), "stdout": out.stdout.strip()},
+        )
+    try:
+        payload = json.loads(out.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise NamespacePolicyError(
+            "PG_MEMORY_PARSE_ERROR",
+            "pg_memory output was not valid JSON",
+            details={"stdout": out.stdout.strip(), "error": str(exc)},
+        ) from exc
+    return payload if isinstance(payload, dict) else {"data": payload}
+
+
+def _now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def resolve_actor(explicit_actor: str | None = None) -> str:
+    if explicit_actor:
+        return explicit_actor.strip()
+
+    actor = os.getenv("OPENCLAW_ACTOR_ID", "").strip()
+    if actor:
+        return actor
+
+    session_key = os.getenv("OPENCLAW_SESSION_KEY", "").strip() or os.getenv("SESSION_KEY", "").strip()
+    if session_key:
+        return f"session:{session_key}"
+
+    return f"user:{getpass.getuser()}"
+
+
+def force_allowlist() -> set[str]:
+    raw = os.getenv("OPENCLAW_FORCE_ALLOWLIST", "")
+    if not raw.strip():
+        return set(FORCE_ALLOWLIST_DEFAULT)
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def validate_project_namespace(namespace: str) -> None:
+    if not PROJECT_NAMESPACE_RE.match(namespace):
+        raise NamespacePolicyError(
+            "INVALID_NAMESPACE",
+            "Namespace must match project namespace regex",
+            details={"namespace": namespace, "regex": PROJECT_NAMESPACE_RE.pattern},
+        )
+
+
+def _parse_active_record(item: dict[str, Any]) -> ActiveNamespaceRecord | None:
+    content = item.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    try:
+        v = int(payload.get("v"))
+        namespace = str(payload["namespace"])
+        updated_at = str(payload["updatedAt"])
+        updated_by = str(payload["updatedBy"])
+        reason = str(payload["reason"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    if v != 1 or reason not in VALID_REASONS:
+        return None
+    if not PROJECT_NAMESPACE_RE.match(namespace):
+        return None
+
+    return ActiveNamespaceRecord(namespace=namespace, updated_at=updated_at, updated_by=updated_by, reason=reason, v=v)
+
+
+def get_active_namespace_record() -> ActiveNamespaceRecord:
+    payload = _run_pg_memory(["search", ACTIVE_NAMESPACE_STORE, "\"namespace\"", "20"])
+    results = payload.get("results", [])
+    if not isinstance(results, list):
+        results = []
+
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        parsed = _parse_active_record(item)
+        if parsed:
+            return parsed
+
+    raise NamespacePolicyError(
+        "ACTIVE_NAMESPACE_UNSET",
+        "Active project namespace is unset; initialize explicitly before writes.",
+        details={"key": ACTIVE_NAMESPACE_KEY},
+    )
+
+
+def set_active_namespace(namespace: str, *, reason: str, actor: str | None = None) -> dict[str, Any]:
+    validate_project_namespace(namespace)
+    if reason not in VALID_REASONS:
+        raise NamespacePolicyError(
+            "INVALID_ACTIVE_NAMESPACE_REASON",
+            "Reason must be one of scope-switch|bootstrap|manual",
+            details={"reason": reason},
+        )
+
+    resolved_actor = resolve_actor(actor)
+    record = ActiveNamespaceRecord(
+        namespace=namespace,
+        updated_at=_now_iso(),
+        updated_by=resolved_actor,
+        reason=reason,
+        v=1,
+    )
+    content = json.dumps(record.to_payload(), ensure_ascii=False)
+    tags = json.dumps(["config", "active-project-namespace", "namespace-integrity"], ensure_ascii=False)
+    store = _run_pg_memory(["store", ACTIVE_NAMESPACE_STORE, content, tags])
+    return {
+        "ok": True,
+        "key": ACTIVE_NAMESPACE_KEY,
+        "namespace": namespace,
+        "reason": reason,
+        "updatedBy": resolved_actor,
+        "updatedAt": record.updated_at,
+        "storeId": store.get("id"),
+    }
+
+
+def append_audit_event(event: dict[str, Any]) -> None:
+    AUDIT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"ts": _now_iso(), **event}
+    with AUDIT_LOG_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def resolve_write_namespace(
+    explicit_namespace: str | None,
+    *,
+    force_cross_project: bool = False,
+    reason: str = "",
+    actor: str | None = None,
+    operation: str = "write",
+) -> dict[str, Any]:
+    active = get_active_namespace_record()
+    resolved_actor = resolve_actor(actor)
+
+    if force_cross_project and not reason.strip():
+        raise NamespacePolicyError(
+            "FORCE_REASON_REQUIRED",
+            "Cross-project force requires --reason <non-empty>",
+            details={"operation": operation},
+        )
+
+    if explicit_namespace:
+        validate_project_namespace(explicit_namespace)
+        target = explicit_namespace
+    else:
+        target = active.namespace
+
+    forced = False
+    if target != active.namespace:
+        if not force_cross_project:
+            raise NamespacePolicyError(
+                "NAMESPACE_MISMATCH",
+                "Requested namespace does not match active namespace; explicit force is required.",
+                details={"activeNamespace": active.namespace, "requestedNamespace": target, "operation": operation},
+            )
+
+        if not reason.strip():
+            raise NamespacePolicyError(
+                "FORCE_REASON_REQUIRED",
+                "Cross-project force requires --reason <non-empty>",
+                details={"activeNamespace": active.namespace, "requestedNamespace": target, "operation": operation},
+            )
+
+        if resolved_actor not in force_allowlist():
+            raise NamespacePolicyError(
+                "FORCE_CROSS_PROJECT_DENIED",
+                "Actor is not authorized for cross-project force override.",
+                details={"actor": resolved_actor, "operation": operation},
+            )
+
+        forced = True
+        append_audit_event(
+            {
+                "event": "cross_project_force_override",
+                "code": "CROSS_PROJECT_FORCE_OVERRIDE",
+                "operation": operation,
+                "actor": resolved_actor,
+                "activeNamespace": active.namespace,
+                "targetNamespace": target,
+                "reason": reason,
+            }
+        )
+
+    return {
+        "ok": True,
+        "namespace": target,
+        "activeNamespace": active.namespace,
+        "forced": forced,
+        "actor": resolved_actor,
+        "forceReason": reason.strip(),
+    }
+
+
+def _print_json(payload: dict[str, Any], *, err: bool = False) -> None:
+    text = json.dumps(payload, ensure_ascii=False)
+    if err:
+        print(text, file=sys.stderr)
+    else:
+        print(text)
+
+
+def _cmd_get_active(_args: argparse.Namespace) -> int:
+    record = get_active_namespace_record()
+    _print_json({"ok": True, "key": ACTIVE_NAMESPACE_KEY, **record.to_payload()})
+    return 0
+
+
+def _cmd_set_active(args: argparse.Namespace) -> int:
+    result = set_active_namespace(args.namespace, reason=args.reason, actor=args.actor)
+    append_audit_event(
+        {
+            "event": "active_namespace_set",
+            "code": "ACTIVE_NAMESPACE_SET",
+            "actor": result["updatedBy"],
+            "namespace": args.namespace,
+            "reason": args.reason,
+        }
+    )
+    _print_json(result)
+    return 0
+
+
+def _cmd_resolve_write(args: argparse.Namespace) -> int:
+    result = resolve_write_namespace(
+        args.namespace,
+        force_cross_project=args.force_cross_project,
+        reason=args.reason or "",
+        actor=args.actor,
+        operation=args.operation,
+    )
+    _print_json(result)
+    return 0
+
+
+def _cmd_audit_event(args: argparse.Namespace) -> int:
+    event: dict[str, Any] = {
+        "event": args.event,
+        "code": args.code or "NAMESPACE_AUDIT_EVENT",
+    }
+    if args.actor:
+        event["actor"] = resolve_actor(args.actor)
+    if args.from_namespace:
+        event["fromNamespace"] = args.from_namespace
+    if args.to_namespace:
+        event["toNamespace"] = args.to_namespace
+    if args.reason:
+        event["reason"] = args.reason
+    if args.operation:
+        event["operation"] = args.operation
+    if args.details_json:
+        try:
+            details = json.loads(args.details_json)
+            if isinstance(details, dict):
+                event.update(details)
+        except json.JSONDecodeError as exc:
+            raise NamespacePolicyError(
+                "INVALID_AUDIT_DETAILS_JSON",
+                "Failed to parse --details-json payload",
+                details={"error": str(exc)},
+            ) from exc
+
+    append_audit_event(event)
+    _print_json({"ok": True, "event": event["event"], "code": event["code"]})
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Namespace integrity policy helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_get = sub.add_parser("get-active")
+    p_get.set_defaults(func=_cmd_get_active)
+
+    p_set = sub.add_parser("set-active")
+    p_set.add_argument("--namespace", required=True)
+    p_set.add_argument("--reason", required=True)
+    p_set.add_argument("--actor")
+    p_set.set_defaults(func=_cmd_set_active)
+
+    p_resolve = sub.add_parser("resolve-write")
+    p_resolve.add_argument("--namespace")
+    p_resolve.add_argument("--force-cross-project", action="store_true")
+    p_resolve.add_argument("--reason", default="")
+    p_resolve.add_argument("--actor")
+    p_resolve.add_argument("--operation", default="write")
+    p_resolve.set_defaults(func=_cmd_resolve_write)
+
+    p_audit = sub.add_parser("audit-event")
+    p_audit.add_argument("--event", required=True)
+    p_audit.add_argument("--code", default="")
+    p_audit.add_argument("--actor")
+    p_audit.add_argument("--operation", default="")
+    p_audit.add_argument("--from-namespace", default="")
+    p_audit.add_argument("--to-namespace", default="")
+    p_audit.add_argument("--reason", default="")
+    p_audit.add_argument("--details-json", default="")
+    p_audit.set_defaults(func=_cmd_audit_event)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    try:
+        return int(args.func(args))
+    except NamespacePolicyError as exc:
+        _print_json(exc.to_dict(), err=True)
+        return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/namespace_sanitize.py
+++ b/tools/namespace_sanitize.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Namespace sanitization utility with dry-run default.
+
+Confidence policy:
+- >=0.90: auto-move candidate
+- 0.70-0.89: manual-review
+- <0.70: no-move
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+TOOLS_DIR = Path(__file__).resolve().parent
+PG_MEMORY = Path(os.getenv("OPENCLAW_PG_MEMORY_PATH", str(TOOLS_DIR / "pg_memory.py")))
+NAMESPACE_POLICY = TOOLS_DIR / "namespace_integrity.py"
+MANIFEST_DIR = Path("/home/node/.openclaw/workspace/.runtime/namespace-integrity/sanitize")
+PROJECT_NS_RE = re.compile(r"project:[a-z0-9][a-z0-9-]{1,63}")
+
+
+def run_pg(args: list[str]) -> dict[str, Any]:
+    cmd = ["python3", str(PG_MEMORY), *args]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "pg_memory failure")
+    data = json.loads(proc.stdout or "{}")
+    return data if isinstance(data, dict) else {"data": data}
+
+
+def run_audit(event: str, code: str, payload: dict[str, Any]) -> None:
+    cmd = [
+        "python3",
+        str(NAMESPACE_POLICY),
+        "audit-event",
+        "--event",
+        event,
+        "--code",
+        code,
+        "--details-json",
+        json.dumps(payload, ensure_ascii=False),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def detect_confidence(content: str, target_namespace: str) -> float:
+    text = content or ""
+    target_hits = text.count(target_namespace)
+    project_mentions = PROJECT_NS_RE.findall(text)
+
+    if target_hits >= 2:
+        return 0.95
+    if target_hits == 1:
+        return 0.85
+    if target_namespace in project_mentions:
+        return 0.8
+    if project_mentions:
+        return 0.6
+    return 0.4
+
+
+def classify(confidence: float) -> str:
+    if confidence >= 0.90:
+        return "auto-move"
+    if confidence >= 0.70:
+        return "manual-review"
+    return "no-move"
+
+
+def build_batch_id() -> str:
+    ts = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"sanitize-{ts}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sanitize namespace contamination with dry-run default")
+    parser.add_argument("--source-namespace", required=True)
+    parser.add_argument("--target-namespace", required=True)
+    parser.add_argument("--query", default="", help="optional search query for candidate retrieval")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--batch-id", default="")
+    parser.add_argument("--apply", action="store_true", help="execute auto-move candidates")
+    parser.add_argument("--reason", default="")
+    args = parser.parse_args()
+
+    batch_id = args.batch_id or build_batch_id()
+    query = args.query.strip() or args.target_namespace
+    dry_run = not args.apply
+
+    search = run_pg(["search", args.source_namespace, query, str(args.limit)])
+    results = search.get("results", []) if isinstance(search, dict) else []
+    if not isinstance(results, list):
+        results = []
+
+    plan: list[dict[str, Any]] = []
+    moved: list[dict[str, Any]] = []
+
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        content = str(item.get("content") or "")
+        rec_id = item.get("id")
+        confidence = detect_confidence(content, args.target_namespace)
+        action = classify(confidence)
+
+        entry: dict[str, Any] = {
+            "id": rec_id,
+            "confidence": round(confidence, 3),
+            "action": action,
+            "sourceNamespace": args.source_namespace,
+            "targetNamespace": args.target_namespace,
+            "preview": content.replace("\n", " ")[:220],
+        }
+        plan.append(entry)
+
+        if dry_run or action != "auto-move":
+            continue
+
+        if not args.reason.strip():
+            raise SystemExit("ERROR_CODE=SANITIZE_REASON_REQUIRED --reason is required when --apply is set")
+
+        copied_content = "\n".join(
+            [
+                "namespace_sanitize_copy v=1",
+                f"batch_id={batch_id}",
+                f"migrated_from_id={rec_id}",
+                f"migrated_from_namespace={args.source_namespace}",
+                "",
+                content,
+            ]
+        )
+        copy_res = run_pg(
+            [
+                "store",
+                args.target_namespace,
+                copied_content,
+                json.dumps(["sanitize-copy", f"batch:{batch_id}", f"from:{args.source_namespace}"], ensure_ascii=False),
+            ]
+        )
+
+        tombstone = {
+            "v": 1,
+            "type": "sanitize_tombstone",
+            "batchId": batch_id,
+            "sourceId": rec_id,
+            "movedToNamespace": args.target_namespace,
+            "movedRecordId": copy_res.get("id"),
+            "reason": args.reason.strip(),
+            "movedAt": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        }
+        tombstone_res = run_pg(
+            [
+                "store",
+                args.source_namespace,
+                json.dumps(tombstone, ensure_ascii=False),
+                json.dumps(["sanitize-tombstone", f"batch:{batch_id}", f"target:{args.target_namespace}"], ensure_ascii=False),
+            ]
+        )
+
+        moved.append(
+            {
+                "sourceId": rec_id,
+                "copiedId": copy_res.get("id"),
+                "tombstoneId": tombstone_res.get("id"),
+                "confidence": round(confidence, 3),
+            }
+        )
+
+    summary = {
+        "ok": True,
+        "batchId": batch_id,
+        "dryRun": dry_run,
+        "sourceNamespace": args.source_namespace,
+        "targetNamespace": args.target_namespace,
+        "query": query,
+        "counts": {
+            "total": len(plan),
+            "autoMove": sum(1 for x in plan if x["action"] == "auto-move"),
+            "manualReview": sum(1 for x in plan if x["action"] == "manual-review"),
+            "noMove": sum(1 for x in plan if x["action"] == "no-move"),
+            "moved": len(moved),
+        },
+        "plan": plan,
+        "moved": moved,
+    }
+
+    MANIFEST_DIR.mkdir(parents=True, exist_ok=True)
+    manifest_path = MANIFEST_DIR / f"{batch_id}.json"
+    manifest_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    summary["manifestPath"] = str(manifest_path)
+
+    event = "namespace_sanitize_dry_run" if dry_run else "namespace_sanitize_applied"
+    code = "NAMESPACE_SANITIZE_DRY_RUN" if dry_run else "NAMESPACE_SANITIZE_APPLIED"
+    run_audit(event, code, {"batchId": batch_id, "source": args.source_namespace, "target": args.target_namespace, "moved": len(moved)})
+
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pg_checkpoint.py
+++ b/tools/pg_checkpoint.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+TOOLS_DIR = Path(__file__).resolve().parent
+PG_MEMORY = Path(os.getenv("OPENCLAW_PG_MEMORY_PATH", str(TOOLS_DIR / "pg_memory.py")))
+NAMESPACE_POLICY = TOOLS_DIR / "namespace_integrity.py"
+
+
+def run_store(namespace: str, content: str, tags: List[str]) -> dict:
+    cmd = [
+        "python3",
+        str(PG_MEMORY),
+        "store",
+        namespace,
+        content,
+        json.dumps(tags, ensure_ascii=False),
+    ]
+    out = subprocess.check_output(cmd, text=True)
+    return json.loads(out)
+
+
+def resolve_namespace(explicit_namespace: str | None, force: bool, reason: str, operation: str) -> dict:
+    cmd = ["python3", str(NAMESPACE_POLICY), "resolve-write", "--operation", operation]
+    if explicit_namespace:
+        cmd.extend(["--namespace", explicit_namespace])
+    if force:
+        cmd.append("--force-cross-project")
+    if reason:
+        cmd.extend(["--reason", reason])
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr or proc.stdout)
+        raise SystemExit(proc.returncode)
+    return json.loads(proc.stdout)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Store a structured checkpoint into Postgres memory.")
+    p.add_argument("--namespace", help="Target project namespace, e.g. project:openclaw-improvement")
+    p.add_argument("--force-cross-project", action="store_true", help="Allow explicit cross-project write when authorized")
+    p.add_argument("--reason", default="", help="Reason for forced cross-project write")
+    p.add_argument("--completed", required=True, help="What was completed")
+    p.add_argument("--decisions", default="", help="Decisions made")
+    p.add_argument("--blockers", default="", help="Current blockers")
+    p.add_argument("--next", dest="next_step", default="", help="Next concrete step")
+    p.add_argument("--artifacts", default="", help="Comma-separated key artifacts/paths")
+    p.add_argument("--extra-tags", default="", help="Comma-separated extra tags")
+    args = p.parse_args()
+
+    resolution = resolve_namespace(
+        args.namespace,
+        force=args.force_cross_project,
+        reason=args.reason,
+        operation="pg_checkpoint",
+    )
+    namespace = resolution["namespace"]
+
+    ts = dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    art = [a.strip() for a in args.artifacts.split(",") if a.strip()]
+
+    lines = [
+        f"checkpoint ts={ts}",
+        f"namespace={namespace}",
+        f"completed: {args.completed}",
+    ]
+    if args.decisions:
+        lines.append(f"decisions: {args.decisions}")
+    if args.blockers:
+        lines.append(f"blockers: {args.blockers}")
+    if args.next_step:
+        lines.append(f"next: {args.next_step}")
+    if art:
+        lines.append("artifacts: " + "; ".join(art))
+
+    content = "\n".join(lines)
+
+    base_tags = ["checkpoint", "durable", "handoff", namespace.replace(":", "-")]
+    extra = [t.strip() for t in args.extra_tags.split(",") if t.strip()]
+    tags = base_tags + extra
+
+    project_store = run_store(namespace, content, tags)
+
+    mirror = (
+        f"checkpoint ts={ts} namespace={namespace} "
+        f"completed={args.completed} next={args.next_step or 'n/a'}"
+    )
+    mirror_tags = ["checkpoint", "index", namespace.replace(":", "-")]
+    index_store = run_store("ops:checkpoints", mirror, mirror_tags)
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "namespace": namespace,
+                "activeNamespace": resolution.get("activeNamespace"),
+                "forced": bool(resolution.get("forced")),
+                "projectEntryId": project_store.get("id"),
+                "indexEntryId": index_store.get("id"),
+                "timestamp": ts,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pg_scope_switch.sh
+++ b/tools/pg_scope_switch.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE_POLICY="${SCRIPT_DIR}/namespace_integrity.py"
+PG_CHECKPOINT="${SCRIPT_DIR}/pg_checkpoint.py"
+
+INIT_MODE=0
+if [[ "${1:-}" == "--init" ]]; then
+  INIT_MODE=1
+  shift
+fi
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 [--init] <from_namespace> <to_namespace> <reason> [next_step]" >&2
+  exit 2
+fi
+
+FROM_NS="$1"
+TO_NS="$2"
+REASON="$3"
+NEXT_STEP="${4:-Start work in target namespace and run pg_rehydrate.py}"
+
+if [[ -z "$REASON" ]]; then
+  echo '{"ok":false,"error":{"code":"SCOPE_SWITCH_REASON_REQUIRED","message":"reason must be non-empty"}}' >&2
+  exit 3
+fi
+
+if [[ "$INIT_MODE" -ne 1 ]]; then
+  set +e
+  ACTIVE_JSON="$(python3 "$NAMESPACE_POLICY" get-active 2>&1)"
+  ACTIVE_RC=$?
+  set -e
+  if [[ $ACTIVE_RC -ne 0 ]]; then
+    echo "$ACTIVE_JSON" >&2
+    exit $ACTIVE_RC
+  fi
+  ACTIVE_NS="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["namespace"])' <<<"$ACTIVE_JSON")"
+  if [[ "$FROM_NS" != "$ACTIVE_NS" ]]; then
+    echo "{\"ok\":false,\"error\":{\"code\":\"SCOPE_SWITCH_FROM_MISMATCH\",\"message\":\"from_namespace must equal active namespace\",\"details\":{\"fromNamespace\":\"$FROM_NS\",\"activeNamespace\":\"$ACTIVE_NS\"}}}" >&2
+    exit 3
+  fi
+
+  python3 "$PG_CHECKPOINT" \
+    --namespace "$FROM_NS" \
+    --completed "Scope switch requested" \
+    --decisions "Switching active scope to $TO_NS" \
+    --next "$NEXT_STEP" \
+    --extra-tags "scope-switch,handoff"
+
+  # Only reached if checkpoint succeeded.
+  python3 "$NAMESPACE_POLICY" set-active --namespace "$TO_NS" --reason "scope-switch" >/dev/null
+
+  # Explicit scope-switch audit after successful active-namespace set.
+  python3 "$NAMESPACE_POLICY" audit-event \
+    --event "scope_switch_completed" \
+    --code "SCOPE_SWITCH_COMPLETED" \
+    --operation "pg_scope_switch" \
+    --from-namespace "$FROM_NS" \
+    --to-namespace "$TO_NS" \
+    --reason "$REASON" >/dev/null
+else
+  python3 "$NAMESPACE_POLICY" set-active --namespace "$TO_NS" --reason "bootstrap" >/dev/null
+  python3 "$NAMESPACE_POLICY" audit-event \
+    --event "scope_switch_initialized" \
+    --code "SCOPE_SWITCH_INITIALIZED" \
+    --operation "pg_scope_switch" \
+    --from-namespace "$FROM_NS" \
+    --to-namespace "$TO_NS" \
+    --reason "$REASON" >/dev/null
+fi
+
+echo "PG_SCOPE_SWITCH_OK from=$FROM_NS to=$TO_NS reason=$REASON"
+echo "Run next: python3 ${SCRIPT_DIR}/pg_rehydrate.py --namespace $TO_NS --limit 5"


### PR DESCRIPTION
## Summary
Implements issue #9 by enforcing project namespace integrity across project-memory write paths.

### What this adds
- New shared resolver/guard: `tools/namespace_integrity.py`
  - canonical active namespace handling via `system:config.active_project_namespace`
  - namespace regex validation
  - strict mismatch handling (`NAMESPACE_MISMATCH`)
  - explicit cross-project override policy with actor allowlist + required reason
  - audit logging for override/switch events
- New sanitize utility: `tools/namespace_sanitize.py`
  - dry-run default
  - confidence tiers (`>=0.90` auto-move, `0.70–0.89` manual, `<0.70` no-move)
  - reversible move flow with tombstones + batch manifest

### Updated write/scope tooling
- `tools/dev_execution_rails.sh`
- `tools/dev_web_external_qa.sh`
- `tools/dev_postmortem.py`
- `tools/dev_lessons.py`
- `tools/pg_checkpoint.py`
- `tools/pg_scope_switch.sh`

These now route namespace resolution through the shared policy instead of silent hardcoded defaults.

### Tests
Added:
- `test/scripts/namespace-integrity/namespace-integrity.test.ts`
- `test/scripts/namespace-integrity/fake_pg_memory.py`

Coverage includes:
1. correct write with active namespace resolution
2. mismatch rejection
3. forced override path + audit behavior
4. scope-switch semantics
5. sanitize dry-run behavior

Closes #9
