### PR TITLE
feat(dev-process): governor MVP enforcement rails + attestation check

### DIFF
--- a/.github/workflows/dev-governor-required-check.yml
+++ b/.github/workflows/dev-governor-required-check.yml
@@ -1,0 +1,42 @@
+name: dev-governor-required-check
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_id:
+        description: "Task ID (e.g. DEV-20260401-governor-mvp-enforcement)"
+        required: true
+        type: string
+      attestation_path:
+        description: "Path to attestation.json in repo workspace"
+        required: true
+        type: string
+      require_overall_pass:
+        description: "Require gates.overall=pass"
+        required: false
+        type: boolean
+        default: true
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate-attestation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate governor attestation (PR mode)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "No default attestation artifact is available in PR context by design."
+          echo "Use workflow_dispatch with task_id + attestation_path (or wire this into your build pipeline artifact fetch)."
+      - name: Validate governor attestation (manual)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          EXTRA=""
+          if [ "${{ inputs.require_overall_pass }}" = "true" ]; then
+            EXTRA="--require-overall-pass"
+          fi
+          python3 scripts/dev/dev_governor_required_check.py \
+            --task-id "${{ inputs.task_id }}" \
+            --attestation "${{ inputs.attestation_path }}" \
+            $EXTRA

--- a/docs/dev-process-governor-mvp.md
+++ b/docs/dev-process-governor-mvp.md
@@ -1,0 +1,57 @@
+# Dev Process Governor (MVP)
+
+This MVP moves software-process enforcement from "agent promises" to tooling:
+
+## Included scripts
+
+- `scripts/dev/dev_governor.py`
+  - Task state machine
+  - Short-lived signed tokens for privileged actions
+  - Fail-closed verification
+  - Audit log in `.runtime/dev-governor/audit.log.jsonl`
+
+- `scripts/dev/dev_execution_rails_enforced.sh`
+  - Requires governor token before running quality gates
+  - Optional issue reference gate for GitHub repos
+  - Emits deterministic `attestation.json`
+
+- `scripts/dev/dev_governor_required_check.py`
+  - Validates an attestation artifact for CI/required-check usage
+
+## State flow
+
+`Intake -> Plan -> Architecture -> ReviewPlan -> ApprovedForImplementation -> Verification -> Done`
+
+## Example
+
+```bash
+TASK_ID=DEV-20260401-governor-mvp-enforcement
+
+# move through planning states
+python3 scripts/dev/dev_governor.py transition --task-id "$TASK_ID" --to Plan --actor main
+python3 scripts/dev/dev_governor.py transition --task-id "$TASK_ID" --to Architecture --actor main
+python3 scripts/dev/dev_governor.py transition --task-id "$TASK_ID" --to ReviewPlan --actor main
+python3 scripts/dev/dev_governor.py transition --task-id "$TASK_ID" --to ApprovedForImplementation --actor reviewer
+
+# issue implementation token
+TOKEN_JSON=$(python3 scripts/dev/dev_governor.py unlock --task-id "$TASK_ID" --action implementation_start)
+TOKEN=$(echo "$TOKEN_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+
+# run enforced rails (fails closed without valid token)
+DEV_GOVERNOR_TOKEN="$TOKEN" scripts/dev/dev_execution_rails_enforced.sh \
+  --task-id "$TASK_ID" \
+  --workdir . \
+  --issue-ref owner/repo#123 \
+  --lint "npm run lint" \
+  --typecheck "npm run typecheck" \
+  --test "npm test" \
+  --smoke "npm run smoke"
+```
+
+## CI integration
+
+A starter workflow exists at:
+
+- `.github/workflows/dev-governor-required-check.yml`
+
+Use it as a required status check after wiring attestation artifact retrieval in your CI path.

--- a/scripts/dev/dev_execution_rails_enforced.sh
+++ b/scripts/dev/dev_execution_rails_enforced.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal fail-closed execution rails for software tasks.
+# Requires governor token verification before running gates.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GOV_SCRIPT="${SCRIPT_DIR}/dev_governor.py"
+
+TASK_ID=""
+WORKDIR="$(pwd)"
+ISSUE_REF=""
+LINT_CMD="${DEV_LINT_CMD:-}"
+TYPE_CMD="${DEV_TYPECHECK_CMD:-}"
+TEST_CMD="${DEV_TEST_CMD:-}"
+SMOKE_CMD="${DEV_SMOKE_CMD:-}"
+GOV_TOKEN="${DEV_GOVERNOR_TOKEN:-}"
+GOV_ACTION="${DEV_GOVERNOR_ACTION:-implementation_start}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --task-id) TASK_ID="$2"; shift 2 ;;
+    --workdir) WORKDIR="$2"; shift 2 ;;
+    --issue-ref) ISSUE_REF="$2"; shift 2 ;;
+    --lint) LINT_CMD="$2"; shift 2 ;;
+    --typecheck) TYPE_CMD="$2"; shift 2 ;;
+    --test) TEST_CMD="$2"; shift 2 ;;
+    --smoke) SMOKE_CMD="$2"; shift 2 ;;
+    --governor-token) GOV_TOKEN="$2"; shift 2 ;;
+    --governor-action) GOV_ACTION="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$TASK_ID" ]] || { echo "Missing --task-id" >&2; exit 2; }
+[[ -n "$GOV_TOKEN" ]] || { echo '{"ok":false,"error":{"code":"GOVERNOR_TOKEN_REQUIRED","message":"missing governor token"}}' >&2; exit 11; }
+
+python3 "$GOV_SCRIPT" verify --task-id "$TASK_ID" --token "$GOV_TOKEN" --action "$GOV_ACTION" >/tmp/dev-governor-verify.json
+GOV_TOKEN_ID="$(python3 -c 'import json; print(json.load(open("/tmp/dev-governor-verify.json")).get("tokenId",""))')"
+GOV_ACTOR="$(python3 -c 'import json; print(json.load(open("/tmp/dev-governor-verify.json")).get("actor",""))')"
+GOV_EXP="$(python3 -c 'import json; print(json.load(open("/tmp/dev-governor-verify.json")).get("exp",""))')"
+
+# Issue gate for GitHub repos (existing issue is acceptable)
+if git -C "$WORKDIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  ORIGIN_URL="$(git -C "$WORKDIR" remote get-url origin 2>/dev/null || true)"
+  if [[ "$ORIGIN_URL" == *"github.com"* ]]; then
+    [[ -n "$ISSUE_REF" ]] || { echo '{"ok":false,"error":{"code":"ISSUE_REQUIRED","message":"--issue-ref required for GitHub repo"}}' >&2; exit 12; }
+  fi
+fi
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${WORKDIR}/.runtime/dev-rails/${TASK_ID}/${TS}"
+mkdir -p "$RUN_DIR"
+
+run_gate() {
+  local name="$1"; local cmd="$2"; local log="$RUN_DIR/${name}.log"
+  if [[ -z "$cmd" ]]; then echo "SKIP: no command configured" > "$log"; echo "skip"; return 0; fi
+  set +e
+  (cd "$WORKDIR" && bash -lc "$cmd") >"$log" 2>&1
+  local rc=$?
+  set -e
+  [[ $rc -eq 0 ]] && echo "pass" || echo "fail"
+}
+
+LINT_STATUS="$(run_gate lint "$LINT_CMD")"
+TYPE_STATUS="$(run_gate typecheck "$TYPE_CMD")"
+TEST_STATUS="$(run_gate test "$TEST_CMD")"
+SMOKE_STATUS="$(run_gate smoke "$SMOKE_CMD")"
+
+OVERALL="pass"
+for s in "$LINT_STATUS" "$TYPE_STATUS" "$TEST_STATUS" "$SMOKE_STATUS"; do
+  [[ "$s" == "fail" ]] && OVERALL="fail"
+done
+
+GIT_COMMIT="$(git -C "$WORKDIR" rev-parse HEAD 2>/dev/null || true)"
+GIT_BRANCH="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+ATTESTATION_PATH="$RUN_DIR/attestation.json"
+
+python3 - <<PY > "$ATTESTATION_PATH"
+import json
+print(json.dumps({
+  "version": 1,
+  "taskId": "${TASK_ID}",
+  "timestampUtc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "workdir": "${WORKDIR}",
+  "git": {"branch": "${GIT_BRANCH}", "commit": "${GIT_COMMIT}"},
+  "governor": {"action": "${GOV_ACTION}", "tokenId": "${GOV_TOKEN_ID}", "actor": "${GOV_ACTOR}", "exp": "${GOV_EXP}"},
+  "issueGate": {"issueRef": "${ISSUE_REF}"},
+  "gates": {"lint": "${LINT_STATUS}", "typecheck": "${TYPE_STATUS}", "test": "${TEST_STATUS}", "smoke": "${SMOKE_STATUS}", "overall": "${OVERALL}"}
+}, ensure_ascii=False, indent=2))
+PY
+
+echo "DEV_EXECUTION_RAILS_ENFORCED_RESULT overall=${OVERALL} run_dir=${RUN_DIR} attestation=${ATTESTATION_PATH}"
+[[ "$OVERALL" == "pass" ]]

--- a/scripts/dev/dev_governor.py
+++ b/scripts/dev/dev_governor.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Minimal process governor for software tasks.
+
+- Enforces task state machine
+- Issues short-lived signed tokens for privileged actions
+- Verifies tokens fail-closed
+- Appends audit events to .runtime/dev-governor/audit.log.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import hashlib
+import hmac
+import json
+import os
+import secrets
+from pathlib import Path
+
+RUNTIME_DIR = Path(".runtime/dev-governor")
+TASKS_DIR = RUNTIME_DIR / "tasks"
+AUDIT_LOG = RUNTIME_DIR / "audit.log.jsonl"
+SECRET_FILE = RUNTIME_DIR / "secret.key"
+
+STATES = [
+    "Intake",
+    "Plan",
+    "Architecture",
+    "ReviewPlan",
+    "ApprovedForImplementation",
+    "Verification",
+    "Done",
+]
+ALLOWED_NEXT = {
+    "Intake": {"Plan"},
+    "Plan": {"Architecture"},
+    "Architecture": {"ReviewPlan"},
+    "ReviewPlan": {"ApprovedForImplementation", "Plan"},
+    "ApprovedForImplementation": {"Verification", "Plan"},
+    "Verification": {"Done", "ApprovedForImplementation", "Plan"},
+    "Done": set(),
+}
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def ensure_dirs() -> None:
+    TASKS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_secret() -> bytes:
+    env = os.getenv("DEV_GOVERNOR_SECRET", "")
+    if env:
+        return env.encode("utf-8")
+    ensure_dirs()
+    if SECRET_FILE.exists():
+        return SECRET_FILE.read_bytes()
+    secret = secrets.token_bytes(32)
+    SECRET_FILE.write_bytes(secret)
+    os.chmod(SECRET_FILE, 0o600)
+    return secret
+
+
+def safe_task_file(task_id: str) -> Path:
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in task_id)
+    return TASKS_DIR / f"{safe}.json"
+
+
+def read_task(task_id: str) -> dict:
+    ensure_dirs()
+    f = safe_task_file(task_id)
+    if not f.exists():
+        t = now_utc()
+        return {
+            "taskId": task_id,
+            "state": "Intake",
+            "createdAt": t,
+            "updatedAt": t,
+            "history": [{"at": t, "state": "Intake", "actor": "system", "reason": "auto-init"}],
+        }
+    return json.loads(f.read_text(encoding="utf-8"))
+
+
+def write_task(task: dict) -> None:
+    ensure_dirs()
+    safe_task_file(task["taskId"]).write_text(json.dumps(task, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def audit(event: dict) -> None:
+    ensure_dirs()
+    with AUDIT_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"at": now_utc(), **event}, ensure_ascii=False) + "\n")
+
+
+def sign(payload: dict, secret: bytes) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    sig = hmac.new(secret, body, hashlib.sha256).digest()
+    b = base64.urlsafe_b64encode(body).decode("ascii").rstrip("=")
+    s = base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+    return f"{b}.{s}"
+
+
+def parse_token(token: str) -> tuple[dict, bytes]:
+    b, s = token.split(".", 1)
+    body = base64.urlsafe_b64decode(b + "=" * (-len(b) % 4))
+    sig = base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+    return json.loads(body.decode("utf-8")), sig
+
+
+def required_state_for_action(action: str) -> str:
+    return {
+        "implementation_start": "ApprovedForImplementation",
+        "done_transition": "Verification",
+        "merge_eligible": "Verification",
+    }.get(action, "ApprovedForImplementation")
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    print(json.dumps({"ok": True, "task": read_task(args.task_id)}, ensure_ascii=False))
+    return 0
+
+
+def cmd_transition(args: argparse.Namespace) -> int:
+    task = read_task(args.task_id)
+    cur = task.get("state", "Intake")
+    dst = args.to
+    if dst not in STATES:
+        print(json.dumps({"ok": False, "error": {"code": "INVALID_STATE", "message": dst}}, ensure_ascii=False))
+        return 2
+    if dst != cur and dst not in ALLOWED_NEXT.get(cur, set()):
+        audit({"type": "transition_denied", "taskId": args.task_id, "from": cur, "to": dst, "actor": args.actor})
+        print(json.dumps({"ok": False, "error": {"code": "INVALID_TRANSITION", "message": f"{cur}->{dst} not allowed"}}, ensure_ascii=False))
+        return 3
+    task["state"] = dst
+    task["updatedAt"] = now_utc()
+    task.setdefault("history", []).append({"at": now_utc(), "state": dst, "actor": args.actor, "reason": args.reason or ""})
+    write_task(task)
+    audit({"type": "transition", "taskId": args.task_id, "from": cur, "to": dst, "actor": args.actor, "reason": args.reason or ""})
+    print(json.dumps({"ok": True, "task": task}, ensure_ascii=False))
+    return 0
+
+
+def cmd_unlock(args: argparse.Namespace) -> int:
+    task = read_task(args.task_id)
+    req = required_state_for_action(args.action)
+    if task.get("state") != req:
+        audit({"type": "unlock_denied", "taskId": args.task_id, "state": task.get("state"), "requiredState": req, "action": args.action})
+        print(json.dumps({"ok": False, "error": {"code": "STATE_NOT_ALLOWED", "message": f"state must be {req}", "state": task.get("state")}}, ensure_ascii=False))
+        return 4
+    now = int(dt.datetime.now(dt.timezone.utc).timestamp())
+    exp = now + int(args.ttl_seconds)
+    token_id = secrets.token_hex(8)
+    payload = {
+        "v": 1,
+        "tokenId": token_id,
+        "taskId": args.task_id,
+        "action": args.action,
+        "actor": args.actor,
+        "iat": now,
+        "exp": exp,
+    }
+    token = sign(payload, load_secret())
+    audit({"type": "unlock_issued", "taskId": args.task_id, "tokenId": token_id, "action": args.action, "actor": args.actor, "exp": exp})
+    print(json.dumps({"ok": True, "taskId": args.task_id, "token": token, "tokenId": token_id, "exp": exp}, ensure_ascii=False))
+    return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    try:
+        payload, sig = parse_token(args.token)
+    except Exception as exc:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": {"code": "TOKEN_INVALID", "message": str(exc)}}, ensure_ascii=False))
+        return 5
+
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    exp_sig = hmac.new(load_secret(), body, hashlib.sha256).digest()
+    if not hmac.compare_digest(sig, exp_sig):
+        print(json.dumps({"ok": False, "error": {"code": "TOKEN_SIGNATURE_INVALID", "message": "signature mismatch"}}, ensure_ascii=False))
+        return 6
+
+    now = int(dt.datetime.now(dt.timezone.utc).timestamp())
+    if int(payload.get("exp", 0)) < now:
+        print(json.dumps({"ok": False, "error": {"code": "TOKEN_EXPIRED", "message": "expired"}}, ensure_ascii=False))
+        return 7
+
+    if payload.get("taskId") != args.task_id:
+        print(json.dumps({"ok": False, "error": {"code": "TOKEN_TASK_MISMATCH", "message": "task mismatch"}}, ensure_ascii=False))
+        return 8
+    if payload.get("action") != args.action:
+        print(json.dumps({"ok": False, "error": {"code": "TOKEN_ACTION_MISMATCH", "message": "action mismatch"}}, ensure_ascii=False))
+        return 9
+
+    task = read_task(args.task_id)
+    req = required_state_for_action(args.action)
+    if task.get("state") != req:
+        print(json.dumps({"ok": False, "error": {"code": "STATE_NOT_ALLOWED", "message": f"state must be {req}", "state": task.get("state")}}, ensure_ascii=False))
+        return 10
+
+    print(json.dumps({"ok": True, "taskId": args.task_id, "tokenId": payload.get("tokenId"), "action": payload.get("action"), "actor": payload.get("actor"), "exp": payload.get("exp")}, ensure_ascii=False))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Dev process governor")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("status")
+    s.add_argument("--task-id", required=True)
+    s.set_defaults(func=cmd_status)
+
+    t = sub.add_parser("transition")
+    t.add_argument("--task-id", required=True)
+    t.add_argument("--to", required=True, choices=STATES)
+    t.add_argument("--actor", default="unknown")
+    t.add_argument("--reason", default="")
+    t.set_defaults(func=cmd_transition)
+
+    u = sub.add_parser("unlock")
+    u.add_argument("--task-id", required=True)
+    u.add_argument("--actor", default="governor")
+    u.add_argument("--action", default="implementation_start", choices=["implementation_start", "done_transition", "merge_eligible"])
+    u.add_argument("--ttl-seconds", type=int, default=900)
+    u.set_defaults(func=cmd_unlock)
+
+    v = sub.add_parser("verify")
+    v.add_argument("--task-id", required=True)
+    v.add_argument("--token", required=True)
+    v.add_argument("--action", required=True, choices=["implementation_start", "done_transition", "merge_eligible"])
+    v.set_defaults(func=cmd_verify)
+    return p
+
+
+if __name__ == "__main__":
+    args = parser().parse_args()
+    raise SystemExit(args.func(args))

--- a/scripts/dev/dev_governor_required_check.py
+++ b/scripts/dev/dev_governor_required_check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Validate governor attestation file for CI required-check usage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def fail(code: str, message: str, rc: int = 1) -> int:
+    print(json.dumps({"ok": False, "error": {"code": code, "message": message}}, ensure_ascii=False))
+    return rc
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--task-id", required=True)
+    ap.add_argument("--attestation", required=True)
+    ap.add_argument("--require-overall-pass", action="store_true")
+    args = ap.parse_args()
+
+    p = Path(args.attestation)
+    if not p.exists():
+        return fail("ATTESTATION_MISSING", f"Missing: {p}")
+
+    try:
+        d = json.loads(p.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return fail("ATTESTATION_INVALID", str(exc))
+
+    if d.get("version") != 1:
+        return fail("ATTESTATION_VERSION_INVALID", "version must be 1")
+    if d.get("taskId") != args.task_id:
+        return fail("TASK_ID_MISMATCH", "attestation taskId mismatch")
+
+    gov = d.get("governor") or {}
+    if not gov.get("tokenId"):
+        return fail("GOVERNOR_TOKEN_MISSING", "governor.tokenId missing")
+    if not gov.get("action"):
+        return fail("GOVERNOR_ACTION_MISSING", "governor.action missing")
+
+    overall = ((d.get("gates") or {}).get("overall"))
+    if args.require_overall_pass and overall != "pass":
+        return fail("GATES_NOT_PASS", f"overall={overall!r}")
+
+    print(json.dumps({"ok": True, "taskId": d.get("taskId"), "tokenId": gov.get("tokenId"), "action": gov.get("action"), "overall": overall}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements a minimal process-governor MVP so software-dev flow is tooling-enforced instead of prompt-trust based.

Closes #24

## What’s included
- `scripts/dev/dev_governor.py`
  - task state machine
  - signed short-lived tokens for privileged actions
  - fail-closed token verification
  - audit log
- `scripts/dev/dev_execution_rails_enforced.sh`
  - requires valid governor token before gates run
  - issue-ref gate for GitHub repos
  - deterministic `attestation.json` output
- `scripts/dev/dev_governor_required_check.py`
  - validates attestation payload (`taskId`, governor token fields, optional overall pass)
- `.github/workflows/dev-governor-required-check.yml`
  - starter required-check workflow path
- `docs/dev-process-governor-mvp.md`
  - usage and integration guide

## Validation
- `python3 -m py_compile scripts/dev/dev_governor.py scripts/dev/dev_governor_required_check.py`
- `bash -n scripts/dev/dev_execution_rails_enforced.sh`
- E2E local smoke with token issuance + enforced rails + attestation validation (pass)

## Notes
- Branch naming rule blocked `issue/*` push due repository rule constraints; pushed under `sai/governor-mvp-enforcement` instead.
- Existing repo-wide pre-commit full check failed in this environment due missing dependency (`ipaddr.js`) outside scope of this change; scoped validation above passed.